### PR TITLE
Add x86 build workflow and update project configs

### DIFF
--- a/.github/workflows/build-x86.yml
+++ b/.github/workflows/build-x86.yml
@@ -1,0 +1,100 @@
+name: Build x86 (Win32) Release
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.3
+      
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+        vcpkgGitCommitId: '7e19f3c64cb636ee21f41bfe8558a6dfaae6236f'
+        vcpkgJsonGlob: 'vcpkg.json'
+        runVcpkgInstall: '--triplet=x86-windows-static --x-wait-for-lock'
+        
+    - name: Set vcpkg environment
+      run: |
+        echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $env:GITHUB_ENV
+        echo "VCPKG_DEFAULT_TRIPLET=x86-windows-static" >> $env:GITHUB_ENV
+        echo "CMAKE_WARN_UNUSED_CLI_VARS=OFF" >> $env:GITHUB_ENV
+        echo "VCPKG_CMAKE_CONFIGURE_OPTIONS=-DCMAKE_WARN_UNUSED_CLI_VARS=OFF" >> $env:GITHUB_ENV
+        
+    - name: Integrate vcpkg with MSBuild
+      run: |
+        & "${{ github.workspace }}/vcpkg/vcpkg.exe" integrate install
+        
+    - name: Build Solution
+      run: |
+        msbuild "Installer.sln" /p:Configuration=Release /p:Platform=Win32 /p:VcpkgEnabled=true /p:VcpkgUseStatic=true /p:VcpkgTriplet=x86-windows-static
+        
+    - name: Verify executable exists
+      run: |
+        if (Test-Path "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe") {
+          Write-Host "KoronePlayerLauncher.exe built successfully!"
+          Get-Item "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe" | Select-Object Name, Length, LastWriteTime
+        } else {
+          Write-Host "KoronePlayerLauncher.exe not found!"
+          Get-ChildItem -Recurse -Name "*.exe" | ForEach-Object { Write-Host "Found: $_" }
+          exit 1
+        }
+        
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: KoronePlayerLauncher-x86-Release
+        path: |
+          BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe
+        retention-days: 30
+        
+    - name: Create release package
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      run: |
+        $version = Get-Date -Format "yyyy.MM.dd-HHmm"
+        $zipName = "KoronePlayerLauncher-x86-$version.zip"
+        
+        # create a temporary dir for packaging
+        New-Item -ItemType Directory -Path "release-package" -Force
+        
+        # copy the exe
+        Copy-Item "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe" "release-package\"
+        
+        # create README for the release
+        $readmeText = "# KoronePlayerLauncher (x86)`n`n"
+        $readmeText += "Build Date: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss UTC')`n"
+        $readmeText += "Commit: ${{ github.sha }}`n"
+        $readmeText += "Platform: Windows x86 (32-bit)`n`n"
+        $readmeText += "## Installation`n"
+        $readmeText += "1. Download KoronePlayerLauncher.exe`n"
+        $readmeText += "2. Run the executable`n`n"
+        $readmeText += "## Requirements`n"
+        $readmeText += "- Windows 7 or later`n"
+        $readmeText += "- Visual C++ Redistributable (if not already installed)"
+        $readmeText | Out-File -FilePath "release-package\README.txt" -Encoding UTF8
+        
+        # create the zip file
+        Compress-Archive -Path "release-package\*" -DestinationPath $zipName -Force
+        
+        Write-Host "Created release package: $zipName"
+        Get-Item $zipName | Select-Object Name, Length
+        
+    - name: Upload release package
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      uses: actions/upload-artifact@v4
+      with:
+        name: Release-Package-x86
+        path: "KoronePlayerLauncher-x86-*.zip"
+        retention-days: 90

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,22 +1,51 @@
 {
   "name": "bootstrapper",
   "version": "1.0.0",
-  "builtin-baseline": "4bb07a326d9b9bce3703272a509e5bc25dd9cfd5",
+  "builtin-baseline": "7e19f3c64cb636ee21f41bfe8558a6dfaae6236f",
   "dependencies": [
     "boost-asio",
     "boost-foreach",
     "boost-lexical-cast",
-    "boost-lexical-cast",
     "boost-property-tree",
     "boost-thread",
     {
+      "name": "boost-asio",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.81.0"
+    },
+    {
       "name": "cpr",
+      "version>=": "1.9.3",
       "features": [
         "ssl"
       ]
     },
-    "rapidjson",
-    "zlib",
-    "minizip"
+    {
+      "name": "rapidjson",
+      "version>=": "2022-06-28#3"
+    },
+    {
+      "name": "zlib",
+      "version>=": "1.2.13"
+    },
+    {
+      "name": "minizip",
+      "version>=": "1.2.13"
+    }
   ]
 }


### PR DESCRIPTION
We are introducing a GitHub Actions workflow for building x86 (Win32) release artifacts. Updates Bootstrapper and BootstrapperClient project files to enable whole program optimization, static linking via vcpkg for Debug|x64 and Debug|Win32, adjusts output directories, and sets C++23 standard for debug builds. Also refines library dependencies, output names, and updates vcpkg.json to specify minimum versions for dependencies and a new baseline. Actions for x64 are coming soon.